### PR TITLE
Add --verbose flag to pretty-quick precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "27": "live-server --open=week-3/27-attributes",
     "28": "live-server --open=week-3/28-git-conflict",
     "29": "live-server --open=week-3/29-combined-skills",
-    "precommit": "pretty-quick --staged",
+    "precommit": "pretty-quick --staged --verbose",
     "serve": "live-server"
   },
   "devDependencies": {


### PR DESCRIPTION
This echoes the name of each file being formatted prior to running
prettier making it easier to find syntax errors which cause prettier
to fail.

This is especially useful when there are a lot of staged files making
it hard to track down where an error is coming from.